### PR TITLE
fixed bug with return key matching when pluses are used in the properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ capiq/tests/manual/settings.py
 
 # cache files
 *.sqlite
+request_count_cache

--- a/capiq/capiq_client.py
+++ b/capiq/capiq_client.py
@@ -39,6 +39,7 @@ class CapIQClient:
             self.enable_error_logging()
         # cache requests for 24 hours
         requests_cache.install_cache('capiq_cache', backend='sqlite', expire_after=86400, allowable_methods=('POST',))
+        requests_cache.get_cache().remove_old_entries(datetime.datetime.fromordinal(datetime.date.today().toordinal()))
 
     # This function retrieves a single data point for a point in time value for a mnemonic either current or
     # historical. Default inputs include a Mnemonic and a Security/Entity Identifier

--- a/capiq/capiq_client.py
+++ b/capiq/capiq_client.py
@@ -123,9 +123,11 @@ class CapIQClient:
                 cache_file.close()
                 self.requent_count = 0
                 self.cache_request_count()
+                return self.requent_count
         else:
             self.requent_count = 0
             self.cache_request_count()
+            return self.requent_count
 
     def make_request(self, identifiers, mnemonics, return_keys, properties, api_function_identifier, multiple_results_expected):
         req_array = []

--- a/capiq/capiq_client.py
+++ b/capiq/capiq_client.py
@@ -2,8 +2,10 @@ import requests
 import json
 import logging
 import requests_cache
+import urllib
 from requests.auth import HTTPBasicAuth
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
 
 class CiqServiceException(Exception):
     pass
@@ -164,7 +166,7 @@ class CapIQClient:
                 logging.info(properties)
                 for property_name, property_value in properties.items():
                     if not (property_name.upper() in return_key["properties"] and \
-                                        return_key["properties"][property_name.upper()] == property_value):
+                                        return_key["properties"][property_name.upper()] == property_value.replace(" ", "+")):
                         match = False
                 if match:
                     return return_key["key"]

--- a/capiq/capiq_client.py
+++ b/capiq/capiq_client.py
@@ -118,7 +118,7 @@ class CapIQClient:
             cache_line = cache_file.readline()
             cache_data = cache_line.split(",")
             if cache_data[0] == str(datetime.datetime.now().date()):
-                return cache_data[1]
+                return int(cache_data[1])
             else:
                 cache_file.close()
                 self.requent_count = 0

--- a/capiq/capiq_client.py
+++ b/capiq/capiq_client.py
@@ -1,3 +1,6 @@
+import datetime
+import os
+
 import requests
 import json
 import logging
@@ -16,6 +19,7 @@ class CapIQClient:
     _username = None
     _password = None
     _debug = False
+    requent_count = 0
 
     def __init__(self, username, password, verify=True, debug=False):
         assert username is not None
@@ -26,6 +30,7 @@ class CapIQClient:
         self._password = password
         self._verify = verify
         self._debug = debug
+        self.requent_count = self.get_cached_request_count()
         if not self._verify:
             requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
         if self._debug:
@@ -90,16 +95,49 @@ class CapIQClient:
     def gdsg(self, identifiers, group_mnemonics, return_keys, properties=None):
         return self.make_request(identifiers, group_mnemonics, return_keys, properties, "GDSG", False)
 
+    def get_request_count(self):
+        return self.requent_count
+
+    def cache_request_count(self):
+        # write the request_count to a file with todays date
+        cache_file = open("./request_count_cache", "w")
+        cache_file.write("{date},{request_count}".format(
+            date=datetime.datetime.now().date(),
+            request_count=self.requent_count
+        ))
+        cache_file.close()
+
+    def get_cached_request_count(self):
+        # check for the cache file
+        #   if present check if the date is today
+        #       if the date is today then get the count and return it
+        #       if the date is not today then overwrite the file with todays date and a count of zero and return 0
+        # if the file is not present then create one with todays date and a count of 0
+        if os.path.isfile("./request_count_cache"):
+            cache_file = open("./request_count_cache", "r")
+            cache_line = cache_file.readline()
+            cache_data = cache_line.split(",")
+            if cache_data[0] == str(datetime.datetime.now().date()):
+                return cache_data[1]
+            else:
+                cache_file.close()
+                self.requent_count = 0
+                self.cache_request_count()
+        else:
+            self.requent_count = 0
+            self.cache_request_count()
 
     def make_request(self, identifiers, mnemonics, return_keys, properties, api_function_identifier, multiple_results_expected):
         req_array = []
         returnee = {}
         mnemonic_return_keys = self.build_mnemonic_return_key_index(mnemonics, return_keys, properties)
+        tmp_request_count = 0
 
         for identifier in identifiers:
             for i, mnemonic in enumerate(mnemonics):
                 req_array.append({"function": api_function_identifier, "identifier": identifier, "mnemonic": mnemonic,
                                   "properties": properties[i] if properties else {}})
+                tmp_request_count += 1
         req = {"inputRequests": req_array}
         response = requests.post(self._endpoint, headers=self._headers, data='inputRequests=' + json.dumps(req),
                                  auth=HTTPBasicAuth(self._username, self._password), verify=self._verify)
@@ -107,6 +145,9 @@ class CapIQClient:
             logging.info("Cap IQ response")
             logging.info(response.json())
             logging.info("reponse from cache: {}".format(response.from_cache))
+        if not response.from_cache:
+            self.requent_count += tmp_request_count
+            self.cache_request_count()
 
         if len(response.json()['GDSSDKResponse']) == 1 and \
                         len(response.json()['GDSSDKResponse'][0]) == 1 and \

--- a/capiq/capiq_client.py
+++ b/capiq/capiq_client.py
@@ -2,7 +2,6 @@ import requests
 import json
 import logging
 import requests_cache
-import urllib
 from requests.auth import HTTPBasicAuth
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ requests
 json
 mock
 requests-cache
+nose
+unittest

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ mock
 requests-cache
 nose
 unittest
+datetime
+os

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,3 @@ requests
 json
 mock
 requests-cache
-nose
-unittest


### PR DESCRIPTION
When a plus is used in the properties it was causing issues with the return key lookup because the results are being parse which is converting the + in the property to a space in the property.  This was causing return keys to be unmatchable when a plus was in the properties value.