### PR TITLE
API Upgrade

### DIFF
--- a/capiq/capiq_client.py
+++ b/capiq/capiq_client.py
@@ -13,8 +13,8 @@ class CiqServiceException(Exception):
     pass
 
 class CapIQClient:
-    _endpoint = 'https://sdk.gds.standardandpoors.com/gdssdk/rest/v2/clientservice.json'
-    _headers = {'Content-Type': 'application/x-www-form-urlencoded', 'Accept-Encoding': 'gzip,deflate'}
+    _endpoint = 'https://api-ciq.marketintelligence.spglobal.com/gdsapi/rest/v3/clientservice.json'
+    _headers = {'Content-Type': 'application/json', 'Accept-Encoding': 'gzip,deflate'}
     _verify = True  # Disable SSL Checks for requests. Set to False to avoid SSL blocking in secured networks
     _username = None
     _password = None
@@ -144,7 +144,7 @@ class CapIQClient:
                                   "properties": properties[i] if properties else {}})
                 tmp_request_count += 1
         req = {"inputRequests": req_array}
-        response = requests.post(self._endpoint, headers=self._headers, data='inputRequests=' + json.dumps(req),
+        response = requests.post(self._endpoint, headers=self._headers, data=json.dumps(req),
                                  auth=HTTPBasicAuth(self._username, self._password), verify=self._verify)
         if self._debug:
             logging.info("Cap IQ response")


### PR DESCRIPTION
Based On Following Email - 

```

Service Advisory: API Cloud Migration

 

Dear Client,

 

As you are aware, we are migrating our S&P API infrastructure to a cloud environment which will require undergoing URL changes. You are receiving this message because our logs indicate that you are currently using V2 endpoints. In order for you to transition to the new cloud infrastructure, additional changes beyond URL update are required. Please make sure you make the below changes to your code before our cutoff date of August 31st 2018 to ensure continuity of service.

 

1.      If you are using client libraries, it is necessary to upgrade to the latest available Client Libraries (V2.1.4) from the support center.

2.      If you are using the end-point https://sdk.gds.standardandpoors.com/gdssdk/rest/v3/clientservice.json you simply need to update the end-point to the below cloud end-points (No other changes are required).

3.      If you are using https://sdk.gds.standardandpoors.com/gdssdk/rest/v2/clientservice.json the following changes are required

a.      Update end-point to https://api-ciq.marketintelligence.spglobal.com/gdsapi/rest/v3/clientservice.json

b.      Update Content-Type to application/json

c.      Update the input Request Format

                                                    i.     OldFormat: inputRequests={inputRequests:[{function:"GDSP",identifier:

"IBM:",mnemonic:"IQ_TOTAL_REV",properties:{PERIODTYPE:"IQ_FQ"}}]}

                                                   ii.     New Format: {inputRequests:[{function:"GDSP",identifier:"IBM:",

mnemonic:" IQ_TOTAL_REV",properties:{PERIODTYPE:"IQ_FQ"}}]}

d.      JSON samples are available on the support center for reference –

http://support.standardandpoors.com/gds/images/stories/Excel_Plug-in/SDK/python_sample.zip

http://support.standardandpoors.com/gds/images/stories/Excel_Plug-in/SDK/jsonSample_RESTv3.zip


```